### PR TITLE
refactor: 重命名组件为Lubanno7UniverSheet并重构核心功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Universheet 组件开发文档
+# Lubanno7UniverSheet 组件开发文档
 
-基于 Element UI 设计风格的 Vue 表格组件，支持嵌套表头、单元格编辑、数据双向绑定、细粒度权限控制，并对外暴露完整实例与生命周期钩子。
+基于 Univer 表格与 Element UI 设计风格的 Vue 表格组件，支持嵌套表头、单元格编辑、数据双向绑定、细粒度权限控制，并对外暴露完整实例与生命周期钩子。
 
 ## 快速开始
 
@@ -8,7 +8,7 @@
 
 ```javascript
 <template>
-  <Universheet
+  <Lubanno7UniverSheet
     :columns="columns"
     :data="tableData"
     :config="config"
@@ -21,10 +21,10 @@
 </template>
 
 <script>
-import Universheet from './universheet.vue';
+import Lubanno7UniverSheet from './Lubanno7UniverSheet.vue';
 
 export default {
-  components: { Universheet },
+  components: { Lubanno7UniverSheet },
   data() {
     return {
       columns: [
@@ -243,7 +243,7 @@ handleDataInitialized(exposed) {
     .getActiveWorkbook()
     .getActiveSheet()
     .getRange(0, 0)
-    .setValue('Hello Universheet');
+    .setValue('Hello Lubanno7UniverSheet');
 }
 
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "universheet-demo",
+  "name": "lubanno7-univer-sheet",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "universheet-demo",
+  "name": "lubanno7-univer-sheet",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/src/components/lubanno7UniverSheet/core.vue
+++ b/src/components/lubanno7UniverSheet/core.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="universheet-wrapper">
+  <div class="lubanno7-univer-sheet-wrapper">
     <div ref="sheetContainer" :style="config.styleOptions"></div>
     <div v-if="pendingUpdates !== 0 || !isTableInitialized" class="custom-loading-mask">
       <div class="loading-content">
@@ -58,7 +58,7 @@ class DisposableManager {
 }
 
 export default {
-  name: 'UniversheetCore',
+  name: 'Lubanno7UniverSheetCore',
   props: {
     // 列配置
     columns: {
@@ -964,7 +964,7 @@ export default {
 </script>
 
 <style scoped>
-.universheet-wrapper {
+.lubanno7-univer-sheet-wrapper {
   position: relative;
   overflow: hidden;
 }

--- a/src/components/lubanno7UniverSheet/index.vue
+++ b/src/components/lubanno7UniverSheet/index.vue
@@ -1,7 +1,7 @@
 <template>
-  <UniversheetCore
+  <Lubanno7UniverSheetCore
     v-if="isComponentAlive"
-    ref="universheetCoreRef"
+    ref="lubanno7UniverSheetCoreRef"
     :columns="columns"
     :data="data"
     :config="mergedConfig"
@@ -14,12 +14,12 @@
 </template>
 
 <script>
-import UniversheetCore from './core.vue'
+import Lubanno7UniverSheetCore from './core.vue'
 
 export default {
-  name: 'Universheet',
+  name: 'Lubanno7UniverSheet',
   components: {
-    UniversheetCore
+    Lubanno7UniverSheetCore
   },
   props: {
     // 列配置
@@ -109,9 +109,9 @@ export default {
         this.$nextTick(() => {
           this.isComponentAlive = true;
         });
-      } else if (this.isTableInitialized && this.$refs.universheetCoreRef) {
+      } else if (this.isTableInitialized && this.$refs.lubanno7UniverSheetCoreRef) {
         // 仅刷新数据，不重建组件
-        this.$refs.universheetCoreRef.refreshTable();
+        this.$refs.lubanno7UniverSheetCoreRef.refreshTable();
       }
     },
     
@@ -128,7 +128,7 @@ export default {
     
     // 处理表格初始化完成事件
     handleTableInitialized() {
-      const coreRef = this.$refs.universheetCoreRef;
+      const coreRef = this.$refs.lubanno7UniverSheetCoreRef;
       // 表格初始化后更新exposed对象
       this.exposed = {
         attributes: {

--- a/src/views/demoQuickStart/index.vue
+++ b/src/views/demoQuickStart/index.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="universheet-demo">
-    <h2>Universheet 示例</h2>
+  <div class="lubanno7-univer-sheet-demo">
+    <h2>Lubanno7UniverSheet 示例</h2>
     <!-- 添加获取数据按钮 -->
     <button @click="getData" class="getDataBtn">获取当前表格数据</button>
-    <Universheet
-      ref="universheetRef"
+    <Lubanno7UniverSheet
+      ref="lubanno7UniverSheetRef"
       :columns="columns"
       :data="tableData"
       :config="config"
@@ -23,12 +23,12 @@
 </template>
 
 <script>
-import Universheet from '@/components/universheet/index.vue';
+import Lubanno7UniverSheet from '@/components/lubanno7UniverSheet/index.vue';
 
 export default {
   name: 'demoQuickStart',
   components: {
-    Universheet
+    Lubanno7UniverSheet
   },
   data() {
     return {
@@ -170,12 +170,12 @@ export default {
     // 添加获取数据方法
     getData() {
       // 通过ref获取表格组件实例
-      const universheet = this.$refs.universheetRef;
-      if (universheet) {
+      const lubanno7UniverSheetRef = this.$refs.lubanno7UniverSheetRef;
+      if (lubanno7UniverSheetRef) {
         // 结束编辑
-        universheet.exposed.methods.endEditing();
+        lubanno7UniverSheetRef.exposed.methods.endEditing();
         // 调用表格组件的方法获取当前数据
-        const currentData = universheet.exposed.methods.getCurrentTableData();
+        const currentData = lubanno7UniverSheetRef.exposed.methods.getCurrentTableData();
         // 更新显示数据
         this.displayData = currentData || [];
         console.log('获取到的表格数据:', currentData);

--- a/src/views/demoStandardUsage/components/demoStandardUsageTable.vue
+++ b/src/views/demoStandardUsage/components/demoStandardUsageTable.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="universheet-demo">
+  <div class="luban7-univer-sheet-demo">
     <div>
       {{ title }}（共:<span style="color:#1890FF">{{ tableLength }}</span>个）
     </div>
-    <Universheet 
+    <Lubanno7UniverSheet 
       v-if="isComponentActive"
-      ref="universheetRef"
+      ref="lubanno7UniverSheetRef"
       :columns="columns"
       :data="tableData"
       :config="config"
@@ -15,7 +15,7 @@
 </template>
 
 <script>
-import Universheet from '@/components/universheet/index.vue';
+import Lubanno7UniverSheet from '@/components/lubanno7UniverSheet/index.vue';
 import { LIST as columnList } from './constant.js';
 import { deepEqual } from '@/utils/deepCompare.js';
 
@@ -32,7 +32,7 @@ export default {
     }
   },
   components: {
-    Universheet
+    Lubanno7UniverSheet
   },
   data() {
     return {
@@ -84,7 +84,7 @@ export default {
       this.originalTableData = this.deepClone(this.tableData);
       this.originalRecordList = this.deepClone(this.recordList);
       // 刷新表格
-      await this.refreshUniversheet(false);
+      await this.refreshLubanno7UniverSheet(false);
     },
 
     // 处理recordAllList变化
@@ -94,7 +94,7 @@ export default {
       this.recordList = recordList;
       this.originalTableData = this.deepClone(this.tableData);
       this.originalRecordList = this.deepClone(this.recordList);
-      this.refreshUniversheet(true);
+      this.refreshLubanno7UniverSheet(true);
     },
 
     // 生成列配置和表格数据
@@ -234,10 +234,10 @@ export default {
     },
 
     // 刷新表格组件
-    async refreshUniversheet(recreate = false) {
-      const universheet = this.$refs.universheetRef;
-      if (universheet?.exposed?.methods?.refreshTable) {
-        await universheet.exposed.methods.refreshTable(recreate);
+    async refreshLubanno7UniverSheet(recreate = false) {
+      const lubanno7UniverSheet = this.$refs.lubanno7UniverSheetRef;
+      if (lubanno7UniverSheet?.exposed?.methods?.refreshTable) {
+        await lubanno7UniverSheet.exposed.methods.refreshTable(recreate);
       }
     },
 
@@ -261,20 +261,20 @@ export default {
       this.tableData.push(this.convertRecordToTableRow(newRecordItem));
       
       // 刷新表格
-      this.refreshUniversheet();
+      this.refreshLubanno7UniverSheet();
     },
 
     // 获取记录变更详情
     getRecordChanges() {
-      const universheet = this.$refs.universheetRef;
-      if (!universheet) {
+      const lubanno7UniverSheet = this.$refs.lubanno7UniverSheetRef;
+      if (!lubanno7UniverSheet) {
         console.error('未找到表格组件实例');
         return this.createEmptyChangeResult();
       }
 
       // 结束编辑并同步最新数据
-      universheet.exposed.methods.endEditing();
-      this.tableData = universheet.exposed.methods.getCurrentTableData();
+      lubanno7UniverSheet.exposed.methods.endEditing();
+      this.tableData = lubanno7UniverSheet.exposed.methods.getCurrentTableData();
       this.updateRecordFromTableData(this.tableData);
 
       // 构建变更结果

--- a/src/views/demoStandardUsage/index.vue
+++ b/src/views/demoStandardUsage/index.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="universheet-demo">
-    <h2>Universheet 示例</h2>
+  <div class="lubanno7-univer-sheet-demo">
+    <h2>Lubanno7UniverSheet 示例</h2>
     <!-- 新增获取变更数据按钮 -->
     <button @click="getRecordChanges" class="getDataBtn">获取变更数据</button>
     <!-- 新增添加记录按钮 -->


### PR DESCRIPTION
重构原有表格组件为Lubanno7UniverSheet，主要变更包括：
1. 重命名所有相关文件、类名和引用
2. 重构核心表格组件，基于Univer实现更强大的功能
3. 新增权限控制、单元格编辑限制等功能
4. 优化性能，使用DisposableManager管理资源
5. 完善错误处理和用户提示信息