### PR TITLE
build: 优化构建配置

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "dev": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "build:lib": "set BUILD_TARGET=library&& vue-cli-service build --target lib --name lubanno7-univer-sheet src/index.js"
+    "build:lib": "set BUILD_TARGET=library && vue-cli-service build --target lib --name lubanno7-univer-sheet --formats umd src/index.js"
   },
   "dependencies": {
     "@univerjs/preset-sheets-core": "0.10.3",

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,6 +1,7 @@
 const { defineConfig } = require('@vue/cli-service')
 module.exports = defineConfig({
   transpileDependencies: true,
+  productionSourceMap: false,
   devServer: {
     port: 8080
   },
@@ -15,6 +16,7 @@ module.exports = defineConfig({
           root: 'Vue'
         }
       })
+      config.optimization.minimize(false)
     }
   }
 })


### PR DESCRIPTION
禁用生产环境的 source map 并调整库构建命令格式