### PR TITLE
fix: 修复表头操作错误提示显示问题并更新版本号

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lubanno7-univer-sheet",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "基于Univer表格与Element UI设计风格的Vue表格组件，支持嵌套表头、单元格编辑、数据双向绑定",
   "keywords": [
     "vue",
@@ -58,7 +58,6 @@
   },
   "browserslist": [
     "> 1%",
-    "last 2 versions",
-    "not dead"
+    "last 2 versions"
   ]
 }

--- a/packages/lubanno7UniverSheet/src/core.vue
+++ b/packages/lubanno7UniverSheet/src/core.vue
@@ -25,8 +25,10 @@ import { UniverSheetsDataValidationPreset } from '@univerjs/preset-sheets-data-v
 import UniverPresetSheetsDataValidationZhCN from '@univerjs/preset-sheets-data-validation/locales/zh-CN'
 import UniverPresetSheetsDataValidationEnUS from '@univerjs/preset-sheets-data-validation/locales/en-US'
 import { createUniver, LocaleType, mergeLocales } from '@univerjs/presets'
+import { Message } from 'element-ui'
 import '@univerjs/preset-sheets-core/lib/index.css'
 import '@univerjs/preset-sheets-data-validation/lib/index.css'
+import 'element-ui/lib/theme-chalk/index.css'
 
 /**
  * 可销毁资源管理器
@@ -666,7 +668,7 @@ export default {
       const { startRow } = params.fromRange._range;
       if (startRow < this.headerRowCount) {
         params.cancel = true;
-        this.$message?.error(this.config.messages.copyHeaderError);
+        Message.error(this.config.messages.copyHeaderError);
       }
     },
 
@@ -709,7 +711,7 @@ export default {
     handleInsertRowCommand(params, event) {
       if (params.range.startRow < this.headerRowCount) {
         event.cancel = true;
-        this.$message?.error(this.config.messages.insertRowError);
+        Message.error(this.config.messages.insertRowError);
       }
     },
 
@@ -717,7 +719,7 @@ export default {
     handleRemoveRowCommand(params, event) {
       if (params.range.startRow < this.headerRowCount) {
         event.cancel = true;
-        this.$message?.error(this.config.messages.deleteRowError);
+        Message.error(this.config.messages.deleteRowError);
       }
     },
 
@@ -728,21 +730,21 @@ export default {
       // 禁止从表头开始填充
       if (sourceRange.startRow < this.headerRowCount) {
         event.cancel = true;
-        this.$message?.error(this.config.messages.autoFillFromHeaderError);
+        Message.error(this.config.messages.autoFillFromHeaderError);
         return;
       }
 
       // 禁止填充到表头
       if (targetRange.startRow < this.headerRowCount) {
         event.cancel = true;
-        this.$message?.error(this.config.messages.autoFillToHeaderError);
+        Message.error(this.config.messages.autoFillToHeaderError);
         return;
       }
 
       // 禁止包含只读单元格的填充
       if (this.hasReadOnlyCellInRange(sourceRange) || this.hasReadOnlyCellInRange(targetRange)) {
         event.cancel = true;
-        this.$message?.error(this.config.messages.readonlyCellAutoFillError);
+        Message.error(this.config.messages.readonlyCellAutoFillError);
       }
     },
 
@@ -767,7 +769,7 @@ export default {
         const message = id === 'sheet.command.add-worksheet-merge'
           ? this.config.messages.mergeCellError
           : this.config.messages.unmergeCellError;
-        this.$message?.error(message);
+        Message.error(message);
       }
     },
 
@@ -778,21 +780,21 @@ export default {
       // 禁止移动表头行
       if (fromRange.startRow < this.headerRowCount) {
         event.cancel = true;
-        this.$message?.error(this.config.messages.moveHeaderError);
+        Message.error(this.config.messages.moveHeaderError);
         return;
       }
 
       // 禁止移动到表头区域
       if (toRange.startRow < this.headerRowCount) {
         event.cancel = true;
-        this.$message?.error(this.config.messages.moveToHeaderError);
+        Message.error(this.config.messages.moveToHeaderError);
         return;
       }
 
       // 禁止包含只读单元格的移动
       if (this.hasReadOnlyCellInRange(fromRange) || this.hasReadOnlyCellInRange(toRange)) {
         event.cancel = true;
-        this.$message?.error(this.config.messages.readonlyCellMoveError);
+        Message.error(this.config.messages.readonlyCellMoveError);
       }
     },
 


### PR DESCRIPTION
- 将错误提示从 `this.$message` 改为直接使用 `Message` 组件
- 移除 browserslist 中不必要的 'not dead' 配置
- 更新 package.json 版本号至 0.3.7